### PR TITLE
Fix docker build

### DIFF
--- a/protochess-front/package.json
+++ b/protochess-front/package.json
@@ -21,7 +21,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-postcss": "^3.1.2",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.1.2",
     "sass": "^1.26.9",
     "spassr": "^1.0.3",


### PR DESCRIPTION
When building with docker I got the error ```Error: Package subpath './compiler.js' is not defined by "exports" in /usr/src/protochess/protochess-front/node_modules/svelte/package.json``` during routifying. Due to the fix https://github.com/sveltejs/rollup-plugin-svelte/pull/151 I upgraded the svelte rollup plugin which fixed the docker build for me.

Very nice project by the way. Unfortunately the website is down though. Are you planning to bring it back up?